### PR TITLE
Feature/reorder chs kafka api call

### DIFF
--- a/src/main/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImpl.java
@@ -37,17 +37,15 @@ public class ExemptionsServiceImpl implements ExemptionsService {
                         .ifPresentOrElse((document::setCreated),
                                 () -> document.setCreated(new Created().setAt(document.getUpdated().getAt())));
 
-                ServiceStatus serviceStatus = exemptionsApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, null, false));
+                repository.save(document);
+                logger.info(String.format("Company exemptions for company number: %s updated in MongoDb for context id: %s",
+                        companyNumber,
+                        contextId));
 
-                if (ServiceStatus.SUCCESS.equals(serviceStatus)) {
-                    logger.info(String.format("ChsKafka api CHANGED invoked updated successfully for context id: %s and company number: %s",
-                            contextId,
-                            companyNumber));
-                    repository.save(document);
-                    logger.info(String.format("Company exemptions for company number: %s updated in MongoDb for context id: %s",
-                            companyNumber,
-                            contextId));
-                }
+                ServiceStatus serviceStatus = exemptionsApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, null, false));
+                logger.info(String.format("ChsKafka api CHANGED invoked updated successfully for context id: %s and company number: %s",
+                        contextId,
+                        companyNumber));
 
                 return serviceStatus;
             } catch (IllegalArgumentException ex) {

--- a/src/main/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImpl.java
@@ -79,13 +79,12 @@ public class ExemptionsServiceImpl implements ExemptionsService {
                 logger.error(String.format("Company exemptions do not exist for company number %s", companyNumber));
                 return ServiceStatus.CLIENT_ERROR;
             }
-            ServiceStatus serviceStatus = exemptionsApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, document.get().getData(), true));
 
-            if (ServiceStatus.SUCCESS.equals(serviceStatus)) {
-                logger.info(String.format("ChsKafka api DELETED invoked successfully for context id: %s and company number: %s", contextId, companyNumber));
-                repository.deleteById(companyNumber);
-                logger.info(String.format("Company exemptions for company number: %s deleted in MongoDb for context id: %s", companyNumber, contextId));
-            }
+            repository.deleteById(companyNumber);
+            logger.info(String.format("Company exemptions for company number: %s deleted in MongoDb for context id: %s", companyNumber, contextId));
+
+            ServiceStatus serviceStatus = exemptionsApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, document.get().getData(), true));
+            logger.info(String.format("ChsKafka api DELETED invoked successfully for context id: %s and company number: %s", contextId, companyNumber));
 
             return serviceStatus;
         } catch (IllegalArgumentException ex) {

--- a/src/test/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImplTest.java
@@ -258,8 +258,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
+        verify(repository).deleteById(COMPANY_NUMBER);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, document.getData(), true));
-        verifyNoMoreInteractions(repository);
     }
 
     @Test
@@ -276,8 +276,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
+        verify(repository).deleteById(COMPANY_NUMBER);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, document.getData(), true));
-        verifyNoMoreInteractions(repository);
     }
 
     @Test
@@ -302,7 +302,6 @@ class ExemptionsServiceImplTest {
         // given
         document.setData(new CompanyExemptions());
         when(repository.findById(any())).thenReturn(Optional.of(document));
-        when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SUCCESS);
         doThrow(ServiceUnavailableException.class).when(repository).deleteById(any());
 
         // when
@@ -311,7 +310,7 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
-        verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, document.getData(), true));
         verify(repository).deleteById(COMPANY_NUMBER);
+        verifyNoInteractions(exemptionsApiService);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImplTest.java
@@ -145,7 +145,6 @@ class ExemptionsServiceImplTest {
         when(repository.findUpdatedExemptions(eq(COMPANY_NUMBER), dateCaptor.capture())).thenReturn(Collections.emptyList());
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
         when(mapper.map(COMPANY_NUMBER, requestBody)).thenReturn(document);
-        when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SUCCESS);
         when(repository.save(document)).thenThrow(ServiceUnavailableException.class);
 
         ServiceStatus serviceStatus = service.upsertCompanyExemptions("", COMPANY_NUMBER, requestBody);
@@ -153,8 +152,8 @@ class ExemptionsServiceImplTest {
         assertEquals(ServiceStatus.SERVER_ERROR, serviceStatus);
         assertEquals(dateString, dateCaptor.getValue());
         verify(repository).findUpdatedExemptions(COMPANY_NUMBER, dateString);
-        verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
         verify(repository).save(document);
+        verifyNoInteractions(exemptionsApiService);
     }
 
     @Test
@@ -164,6 +163,7 @@ class ExemptionsServiceImplTest {
         when(repository.findUpdatedExemptions(eq(COMPANY_NUMBER), dateCaptor.capture())).thenReturn(Collections.emptyList());
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
         when(mapper.map(COMPANY_NUMBER, requestBody)).thenReturn(document);
+        when(repository.save(any())).thenReturn(document);
         when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SERVER_ERROR);
 
         // when
@@ -172,8 +172,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
+        verify(repository).save(document);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
-        verifyNoMoreInteractions(repository);
     }
 
     @Test


### PR DESCRIPTION
* Save or delete a record in the database before calling chs-kafka-api to ensure resource-change-publisher
  doesn't get an outdated record.