### PR TITLE
DSND-1406 Fix regex logic error

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -4,4 +4,4 @@ weight: 999998
 routes:
   1: ^/company-exemptions/healthcheck
   2: ^/company-exemptions/(.*)/internal
-  3: ^/company/(.*){8}/exemptions$
+  3: ^/company/(.){8}/exemptions$


### PR DESCRIPTION
* Changes the GET route to capture exactly 8 characters for company number.

[DSND-1406](https://companieshouse.atlassian.net/browse/DSND-1406)

[DSND-1406]: https://companieshouse.atlassian.net/browse/DSND-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSND-1406]: https://companieshouse.atlassian.net/browse/DSND-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ