### PR TITLE
DSND-1406 Change company number character limit

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -4,4 +4,4 @@ weight: 999998
 routes:
   1: ^/company-exemptions/healthcheck
   2: ^/company-exemptions/(.*)/internal
-  3: ^/company/(.){8}/exemptions$
+  3: ^/company/(.){0,10}/exemptions$


### PR DESCRIPTION
* Due to some edge cases where a company has 7 or 10 characters the route must include company numbers up to 10 characters long.

[DSND-1406 ](https://companieshouse.atlassian.net/browse/DSND-1406)