### PR TITLE
DSND-1576 Send streaming notification before persisting changes to database

### DIFF
--- a/src/feature/resources/features/exemptions/delete_exemptions.feature
+++ b/src/feature/resources/features/exemptions/delete_exemptions.feature
@@ -10,8 +10,8 @@ Feature: Deletes company exemption resource from the database
     And the resource does not exist in the database for "<company_number>"
 
     Examples:
-    | company_number |
-    | 00006400       |
+      | company_number |
+      | 00006400       |
 
   Scenario Outline: 404 status code is returned when resource not found in Mongo
 
@@ -22,8 +22,8 @@ Feature: Deletes company exemption resource from the database
     And the CHS Kafka API service is not invoked
 
     Examples:
-    | company_number |
-    | 00006400       |
+      | company_number |
+      | 00006400       |
 
   Scenario Outline: A DELETE request sent when Mongo is unavailable
 
@@ -34,8 +34,8 @@ Feature: Deletes company exemption resource from the database
     And the CHS Kafka API service is not invoked
 
     Examples:
-    | company_number |
-    | 00006400       |
+      | company_number |
+      | 00006400       |
 
   Scenario Outline: A DELETE request sent when CHS Kafka Api is unavailable
 
@@ -43,10 +43,11 @@ Feature: Deletes company exemption resource from the database
     And exemptions exists for company number "<company_number>"
     When a request is sent to the delete endpoint for "<company_number>"
     Then a response status code of 503 should be returned
+    And the exemptions "<exemptions>" for "<company_number>" exist in the database
 
     Examples:
-    | company_number |
-    | 00006400       |
+      | company_number | exemptions                    |
+      | 00006400       | retrieved_exemptions_resource |
 
   Scenario Outline: A DELETE request is sent without ERIC headers causing an unauthorised error
 
@@ -54,5 +55,5 @@ Feature: Deletes company exemption resource from the database
     Then a response status code of 401 should be returned
 
     Examples:
-    | company_number |
-    | 00006400       |
+      | company_number |
+      | 00006400       |

--- a/src/feature/resources/features/exemptions/upsert_exemptions.feature
+++ b/src/feature/resources/features/exemptions/upsert_exemptions.feature
@@ -22,17 +22,17 @@ Feature: Upsert company exemption resource to database
         | company_number  | file                              |
         | 00006400        | exemptions_bad_request            |
 
-    Scenario Outline: Processing exemptions upsert unsuccessfully but information saved to database
+    Scenario Outline: Processing exemptions upsert fails call to chs-kafka-api and does not persist to the database
 
       Given the CHS Kafka API service is unavailable
       When a PUT request matching payload within "<file>" is sent for "<company_number>"
       Then a response status code of 503 should be returned
-      And the exemptions "<exemptions>" for "<company_number>" have been saved in the database
       And the CHS Kafka API service is invoked for upsert with "<company_number>"
+      And the resource does not exist in the database for "<company_number>"
 
       Examples:
-        | company_number  | file                   | exemptions                        |
-        | 00006400        | exemptions_api_request | retrieved_exemptions_resource |
+        | company_number  | file                   |
+        | 00006400        | exemptions_api_request |
 
   Scenario Outline: Processing exemptions upsert while database is down
 

--- a/src/test/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/ExemptionsServiceImplTest.java
@@ -145,6 +145,7 @@ class ExemptionsServiceImplTest {
         when(repository.findUpdatedExemptions(eq(COMPANY_NUMBER), dateCaptor.capture())).thenReturn(Collections.emptyList());
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
         when(mapper.map(COMPANY_NUMBER, requestBody)).thenReturn(document);
+        when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SUCCESS);
         when(repository.save(document)).thenThrow(ServiceUnavailableException.class);
 
         ServiceStatus serviceStatus = service.upsertCompanyExemptions("", COMPANY_NUMBER, requestBody);
@@ -152,8 +153,8 @@ class ExemptionsServiceImplTest {
         assertEquals(ServiceStatus.SERVER_ERROR, serviceStatus);
         assertEquals(dateString, dateCaptor.getValue());
         verify(repository).findUpdatedExemptions(COMPANY_NUMBER, dateString);
+        verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
         verify(repository).save(document);
-        verifyNoInteractions(exemptionsApiService);
     }
 
     @Test
@@ -163,7 +164,6 @@ class ExemptionsServiceImplTest {
         when(repository.findUpdatedExemptions(eq(COMPANY_NUMBER), dateCaptor.capture())).thenReturn(Collections.emptyList());
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
         when(mapper.map(COMPANY_NUMBER, requestBody)).thenReturn(document);
-        when(repository.save(any())).thenReturn(document);
         when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SERVER_ERROR);
 
         // when
@@ -172,8 +172,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
-        verify(repository).save(document);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
+        verifyNoMoreInteractions(repository);
     }
 
     @Test
@@ -258,8 +258,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
-        verify(repository).deleteById(COMPANY_NUMBER);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, document.getData(), true));
+        verifyNoMoreInteractions(repository);
     }
 
     @Test
@@ -276,8 +276,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
-        verify(repository).deleteById(COMPANY_NUMBER);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, document.getData(), true));
+        verifyNoMoreInteractions(repository);
     }
 
     @Test
@@ -302,6 +302,7 @@ class ExemptionsServiceImplTest {
         // given
         document.setData(new CompanyExemptions());
         when(repository.findById(any())).thenReturn(Optional.of(document));
+        when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SUCCESS);
         doThrow(ServiceUnavailableException.class).when(repository).deleteById(any());
 
         // when
@@ -310,7 +311,7 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
+        verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, document.getData(), true));
         verify(repository).deleteById(COMPANY_NUMBER);
-        verifyNoInteractions(exemptionsApiService);
     }
 }


### PR DESCRIPTION
* Sends a resource changed request to chs-kafka-api before persisting any changes to the database, changes can be an insert/update or a delete. This is preferential to persisting the changes first, because if the resource changed request fails afterwards then it won't be resent, as the delta retried will now be out of date.
* Updated unit tests.
* Updated integration tests.

Note: Tested chs-kafka-api down and MongoDB down locally.

[DSND-1576](https://companieshouse.atlassian.net/browse/DSND-1576)

[DSND-1576]: https://companieshouse.atlassian.net/browse/DSND-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ