### PR TITLE
DSND-3020: Change processing order

### DIFF
--- a/src/feature/java/uk/gov/companieshouse/exemptions/exemptions/ExemptionsSteps.java
+++ b/src/feature/java/uk/gov/companieshouse/exemptions/exemptions/ExemptionsSteps.java
@@ -255,6 +255,11 @@ public class ExemptionsSteps {
         assertThat(exemptionsRepository.findById(companyNumber)).isEmpty();
     }
 
+    @And("the resource has been persisted for {string}")
+    public void verifyResourceHasBeenPersistedInTheDatabase(String companyNumber) {
+        assertThat(exemptionsRepository.findById(companyNumber)).isNotNull();
+    }
+
     @When("a DELETE request is sent without ERIC headers for {string}")
     public void deleteRequestSentWithoutEricHeaders(String companyNumber) {
         HttpHeaders headers = new HttpHeaders();

--- a/src/feature/resources/features/exemptions/upsert_exemptions.feature
+++ b/src/feature/resources/features/exemptions/upsert_exemptions.feature
@@ -34,13 +34,13 @@ Feature: Upsert company exemption resource to database
       | company_number | file                   |
       | 00006400       | exemptions_bad_request |
 
-  Scenario Outline: Processing exemptions upsert fails call to chs-kafka-api and does not persist to the database
+  Scenario Outline: Processing exemptions upsert fails call to chs-kafka-api and returns 503
 
     Given the CHS Kafka API service is unavailable
     When a PUT request matching payload within "<file>" is sent for "<company_number>"
     Then a response status code of 503 should be returned
     And the CHS Kafka API service is invoked for upsert with "<company_number>"
-    And the resource does not exist in the database for "<company_number>"
+    And the resource has been persisted for "<company_number>"
 
     Examples:
       | company_number | file                   |

--- a/src/main/java/uk/gov/companieshouse/exemptions/model/CompanyExemptionsDocument.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/model/CompanyExemptionsDocument.java
@@ -83,4 +83,15 @@ public class CompanyExemptionsDocument {
     public int hashCode() {
         return Objects.hash(id, created, data, deltaAt, updated);
     }
+
+    @Override
+    public String toString() {
+        return "CompanyExemptionsDocument{" +
+                "id='" + id + '\'' +
+                ", created=" + created +
+                ", data=" + data +
+                ", deltaAt='" + deltaAt + '\'' +
+                ", updated=" + updated +
+                '}';
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/exemptions/model/CompanyExemptionsDocument.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/model/CompanyExemptionsDocument.java
@@ -83,15 +83,4 @@ public class CompanyExemptionsDocument {
     public int hashCode() {
         return Objects.hash(id, created, data, deltaAt, updated);
     }
-
-    @Override
-    public String toString() {
-        return "CompanyExemptionsDocument{" +
-                "id='" + id + '\'' +
-                ", created=" + created +
-                ", data=" + data +
-                ", deltaAt='" + deltaAt + '\'' +
-                ", updated=" + updated +
-                '}';
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImpl.java
@@ -38,11 +38,11 @@ public class ExemptionsServiceImpl implements ExemptionsService {
         try {
             Optional<CompanyExemptionsDocument> existingDocument = repository.findById(companyNumber);
 
-            // If the document does not exist OR if the delta_at in the request is after the delta_at on the document
+            // If the document does not exist OR if the delta_at in the request is not before the delta_at on the document
             if (existingDocument.isEmpty() ||
                     StringUtils.isBlank(existingDocument.get().getDeltaAt()) ||
-                    requestBody.getInternalData().getDeltaAt()
-                            .isAfter(ZonedDateTime.parse(existingDocument.get().getDeltaAt(), FORMATTER)
+                    !requestBody.getInternalData().getDeltaAt()
+                            .isBefore(ZonedDateTime.parse(existingDocument.get().getDeltaAt(), FORMATTER)
                                     .toOffsetDateTime())) {
                 CompanyExemptionsDocument document = mapper.map(companyNumber, requestBody);
 

--- a/src/main/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImpl.java
@@ -57,10 +57,8 @@ public class ExemptionsServiceImpl implements ExemptionsService {
                         companyNumber,
                         contextId));
 
-                ServiceStatus serviceStatus = exemptionsApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, null, false));
-                logger.info(String.format("ChsKafka api CHANGED invoked for context id: %s and company number: %s",
-                        contextId,
-                        companyNumber));
+                ServiceStatus serviceStatus = exemptionsApiService
+                        .invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, null, false));
 
                 if (!ServiceStatus.SUCCESS.equals(serviceStatus)) {
                     logger.info(String.format("Chs Kafka API call FAILED for context id: %s", contextId));

--- a/src/main/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImpl.java
@@ -52,16 +52,22 @@ public class ExemptionsServiceImpl implements ExemptionsService {
                         .ifPresentOrElse(document::setCreated,
                                 () -> document.setCreated(new Created().setAt(document.getUpdated().at())));
 
+                repository.save(document);
+                logger.info(String.format("Company exemptions for company number: %s updated in MongoDb for context id: %s",
+                        companyNumber,
+                        contextId));
+
                 ServiceStatus serviceStatus = exemptionsApiService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, null, false));
-                logger.info(String.format("ChsKafka api CHANGED invoked updated successfully for context id: %s and company number: %s",
+                logger.info(String.format("ChsKafka api CHANGED invoked for context id: %s and company number: %s",
                         contextId,
                         companyNumber));
 
-                if (ServiceStatus.SUCCESS.equals(serviceStatus)) {
-                    repository.save(document);
-                    logger.info(String.format("Company exemptions for company number: %s updated in MongoDb for context id: %s",
-                            companyNumber,
-                            contextId));
+                if (!ServiceStatus.SUCCESS.equals(serviceStatus)) {
+                    logger.info(String.format("Chs Kafka API call FAILED for context id: %s", contextId));
+                } else {
+                    logger.info(String.format("ChsKafka api CHANGED invoked SUCCESSFULLY for context id: %s and company number: %s",
+                            contextId,
+                            companyNumber));
                 }
                 return serviceStatus;
             } else {

--- a/src/test/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/service/ExemptionsServiceImplTest.java
@@ -154,14 +154,13 @@ class ExemptionsServiceImplTest {
     void saveToRepositoryError() {
         when(repository.findById(COMPANY_NUMBER)).thenReturn(Optional.empty());
         when(mapper.map(COMPANY_NUMBER, requestBody)).thenReturn(document);
-        when(exemptionsApiService.invokeChsKafkaApi(any())).thenReturn(ServiceStatus.SUCCESS);
         when(repository.save(document)).thenThrow(ServiceUnavailableException.class);
 
         ServiceStatus serviceStatus = service.upsertCompanyExemptions("", COMPANY_NUMBER, requestBody);
 
         assertEquals(ServiceStatus.SERVER_ERROR, serviceStatus);
-        verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
         verify(repository).save(document);
+        verifyNoInteractions(exemptionsApiService);
     }
 
     @Test
@@ -178,8 +177,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
+        verify(repository).save(document);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
-        verifyNoMoreInteractions(repository);
     }
 
     @Test
@@ -196,8 +195,8 @@ class ExemptionsServiceImplTest {
         // then
         assertEquals(ServiceStatus.SERVER_ERROR, actual);
         verify(repository).findById(COMPANY_NUMBER);
+        verify(repository).save(document);
         verify(exemptionsApiService).invokeChsKafkaApi(new ResourceChangedRequest("", COMPANY_NUMBER, null, false));
-        verifyNoMoreInteractions(repository);
     }
 
     @Test


### PR DESCRIPTION
This PR changes the order of logic for a PUT request where a document is first save and then the call to chs-kafka-api is made.

[DSND-3020](https://companieshouse.atlassian.net/browse/DSND-3020)

[DSND-3020]: https://companieshouse.atlassian.net/browse/DSND-3020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ