### PR TITLE
DSND-3091: Stop null fields going out on stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ test-unit:
 test-integration:
 	mvn integration-test verify -Dskip.unit.tests=true failsafe:verify
 
+.PHONY: docker-image
+docker-image: clean
+	mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true jib:dockerBuild
+
 .PHONY: package
 package:
 ifndef version

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ Application specific attributes | Value                                | Descrip
 ### Useful Links
 - [ECS service config dev repository](https://github.com/companieshouse/ecs-service-configs-dev)
 - [ECS service config production repository](https://github.com/companieshouse/ecs-service-configs-production)
+
+### Local Testing on CHS Dev
+1. Clone `docker-chs-development` from GitHub. 
+2. Change directory in your terminal to the cloned `docker-chs-development` directory 
+3. Ensure this service is enabled in chs-dev by running `chs-dev services enable company-exemptions-data-api`
+4. Build the local image using `make docker-image`
+5. Spin up the service using `chs-dev up`
+6. Shut down the service using `chs-dev down`

--- a/src/main/java/uk/gov/companieshouse/exemptions/controller/ControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/controller/ControllerExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import uk.gov.companieshouse.exemptions.exception.BadRequestException;
 import uk.gov.companieshouse.exemptions.exception.ConflictException;
 import uk.gov.companieshouse.exemptions.exception.NotFoundException;
+import uk.gov.companieshouse.exemptions.exception.SerDesException;
 import uk.gov.companieshouse.exemptions.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -54,8 +55,8 @@ public class ControllerExceptionHandler {
                 .build();
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<Void> handleUnknownException(Exception ex) {
+    @ExceptionHandler(value = {Exception.class, SerDesException.class})
+    public ResponseEntity<Void> handleInternalServerError(Exception ex) {
         LOGGER.error(ex.getClass().getName(), ex);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/uk/gov/companieshouse/exemptions/exception/SerDesException.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/exception/SerDesException.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.exemptions.exception;
+
+public class SerDesException extends RuntimeException {
+
+    public SerDesException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/exemptions/util/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/exemptions/util/ResourceChangedRequestMapper.java
@@ -1,22 +1,32 @@
 package uk.gov.companieshouse.exemptions.util;
 
+import static uk.gov.companieshouse.exemptions.ExemptionsApplication.APPLICATION_NAME_SPACE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.exemptions.exception.SerDesException;
 import uk.gov.companieshouse.exemptions.model.ResourceChangedRequest;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class ResourceChangedRequestMapper {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(APPLICATION_NAME_SPACE);
     private static final String CHANGED = "changed";
     private static final String DELETED = "deleted";
 
     private final Supplier<Instant> instantSupplier;
+    private final ObjectMapper objectMapper;
 
-    public ResourceChangedRequestMapper(Supplier<Instant> instantSupplier) {
+    public ResourceChangedRequestMapper(Supplier<Instant> instantSupplier, ObjectMapper objectMapper) {
         this.instantSupplier = instantSupplier;
+        this.objectMapper = objectMapper;
     }
 
     public ChangedResource mapChangedEvent(ResourceChangedRequest request) {
@@ -25,11 +35,20 @@ public class ResourceChangedRequestMapper {
 
     public ChangedResource mapDeletedEvent(ResourceChangedRequest request) {
         ChangedResource changedResource = buildChangedResource(DELETED, request);
-        changedResource.setDeletedData(request.document().getData());
-        return changedResource;
+        try {
+            // Removes null fields using Jackson's Object Mapper
+            Object data = objectMapper.readValue(objectMapper.writeValueAsString(request.document().getData()), Object.class);
+            changedResource.setDeletedData(data);
+
+            return changedResource;
+        } catch (JsonProcessingException ex) {
+            final String msg = "Failed to serialise/deserialise deleted data";
+            LOGGER.error(msg);
+            throw new SerDesException(msg, ex);
+        }
     }
 
-    private ChangedResource buildChangedResource(final String type, ResourceChangedRequest request){
+    private ChangedResource buildChangedResource(final String type, ResourceChangedRequest request) {
         ChangedResourceEvent event = new ChangedResourceEvent()
                 .publishedAt(DateUtils.publishedAtString(this.instantSupplier.get()))
                 .type(type);

--- a/src/test/java/uk/gov/companieshouse/exemptions/util/ResourceChangedRequestMapperIT.java
+++ b/src/test/java/uk/gov/companieshouse/exemptions/util/ResourceChangedRequestMapperIT.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.exemptions.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
+import uk.gov.companieshouse.api.exemptions.Exemptions;
+import uk.gov.companieshouse.exemptions.model.CompanyExemptionsDocument;
+import uk.gov.companieshouse.exemptions.model.ResourceChangedRequest;
+
+@SpringBootTest
+class ResourceChangedRequestMapperIT {
+
+    private static final String CONTEXT_ID = "CONTEXT_ID";
+    private static final String COMPANY_NUMBER = "12345678";
+
+    @Autowired
+    private ResourceChangedRequestMapper mapper;
+
+    @Test
+    void shouldRemoveNullValuesFromDeletedDataUsingObjectMapper() {
+        // given
+        ResourceChangedRequest request = new ResourceChangedRequest(CONTEXT_ID, COMPANY_NUMBER, new CompanyExemptionsDocument()
+                .setData(new CompanyExemptions()
+                        .exemptions(new Exemptions())), true);
+
+        // when
+        ChangedResource actual = mapper.mapDeletedEvent(request);
+
+        // then
+        assertFalse(actual.getDeletedData().toString().contains("null"));
+    }
+}


### PR DESCRIPTION
This PR removes null fields from the stream messages.

Tested locally.

[DSND-3091](https://companieshouse.atlassian.net/browse/DSND-3091)

[DSND-3091]: https://companieshouse.atlassian.net/browse/DSND-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ